### PR TITLE
Minimum viable PoW change

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -294,7 +294,8 @@ public:
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");
 
-        consensus.HardforkTime = std::numeric_limits<int64_t>::max();
+        consensus.HardforkTime = 1296688603;  // Just past the genesis block
+        consensus.PowChangeAlgo = HashAlgorithm::NUM_HASH_ALGOS;
         consensus.nPowChangeTargetShift = 20;
 
         // By default assume that the signatures in ancestors of this block are valid.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -118,7 +118,7 @@ public:
         nPruneAfterHeight = 100000;
 
         genesis = CreateGenesisBlock(1231006505, 2083236893, 0x1d00ffff, 1, 50 * COIN);
-        consensus.hashGenesisBlock = genesis.GetHash();
+        consensus.hashGenesisBlock = genesis.GetHash(consensus);
         assert(consensus.hashGenesisBlock == uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
         assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 
@@ -220,7 +220,7 @@ public:
         nPruneAfterHeight = 1000;
 
         genesis = CreateGenesisBlock(1296688602, 414098458, 0x1d00ffff, 1, 50 * COIN);
-        consensus.hashGenesisBlock = genesis.GetHash();
+        consensus.hashGenesisBlock = genesis.GetHash(consensus);
         assert(consensus.hashGenesisBlock == uint256S("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
         assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 
@@ -308,7 +308,7 @@ public:
         nPruneAfterHeight = 1000;
 
         genesis = CreateGenesisBlock(1296688602, 2, 0x207fffff, 1, 50 * COIN);
-        consensus.hashGenesisBlock = genesis.GetHash();
+        consensus.hashGenesisBlock = genesis.GetHash(consensus);
         assert(consensus.hashGenesisBlock == uint256S("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
         assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -99,6 +99,8 @@ public:
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000003f94d1ad391682fe038bf5");
 
+        consensus.HardforkTime = std::numeric_limits<int64_t>::max();
+
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x00000000000000000013176bf8d7dfeab4e1db31dc93bc311b436e82ab226b90"); //453354
 
@@ -203,6 +205,8 @@ public:
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000001f057509eba81aed91");
 
+        consensus.HardforkTime = std::numeric_limits<int64_t>::max();
+
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x00000000000128796ee387cf110ccb9d2f36cffaf7f73079c995377c65ac0dcc"); //1079274
 
@@ -287,6 +291,8 @@ public:
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");
+
+        consensus.HardforkTime = std::numeric_limits<int64_t>::max();
 
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x00");

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -100,6 +100,7 @@ public:
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000003f94d1ad391682fe038bf5");
 
         consensus.HardforkTime = std::numeric_limits<int64_t>::max();
+        consensus.nPowChangeTargetShift = 20;
 
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x00000000000000000013176bf8d7dfeab4e1db31dc93bc311b436e82ab226b90"); //453354
@@ -206,6 +207,7 @@ public:
         consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000001f057509eba81aed91");
 
         consensus.HardforkTime = std::numeric_limits<int64_t>::max();
+        consensus.nPowChangeTargetShift = 20;
 
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x00000000000128796ee387cf110ccb9d2f36cffaf7f73079c995377c65ac0dcc"); //1079274
@@ -293,6 +295,7 @@ public:
         consensus.nMinimumChainWork = uint256S("0x00");
 
         consensus.HardforkTime = std::numeric_limits<int64_t>::max();
+        consensus.nPowChangeTargetShift = 20;
 
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x00");

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -66,9 +66,14 @@ struct Params {
 
     /** Hardfork parameters */
     int64_t HardforkTime;
+    HashAlgorithm PowChangeAlgo;
     int nPowChangeTargetShift;
     HashAlgorithm PowAlgorithmForTime(int64_t nTime) const {
-        return HashAlgorithm::SHA256d;
+        if (nTime >= HardforkTime) {
+            return PowChangeAlgo;
+        } else {
+            return HashAlgorithm::SHA256d;
+        }
     }
 
     uint256 defaultAssumeValid;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -70,6 +70,10 @@ struct Params {
     int nPowChangeTargetShift;
     HashAlgorithm PowAlgorithmForTime(int64_t nTime) const {
         if (nTime >= HardforkTime) {
+            if (PowChangeAlgo == HashAlgorithm::NUM_HASH_ALGOS) {
+                // Indicates a rotating hash algo, for testing
+                return (HashAlgorithm)((nTime / 3600) % (unsigned int)HashAlgorithm::NUM_HASH_ALGOS);
+            }
             return PowChangeAlgo;
         } else {
             return HashAlgorithm::SHA256d;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -62,6 +62,10 @@ struct Params {
     int64_t nPowTargetTimespan;
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
     uint256 nMinimumChainWork;
+
+    /** Hardfork parameters */
+    int64_t HardforkTime;
+
     uint256 defaultAssumeValid;
 };
 } // namespace Consensus

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -66,6 +66,7 @@ struct Params {
 
     /** Hardfork parameters */
     int64_t HardforkTime;
+    int nPowChangeTargetShift;
     HashAlgorithm PowAlgorithmForTime(int64_t nTime) const {
         return HashAlgorithm::SHA256d;
     }

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_CONSENSUS_PARAMS_H
 #define BITCOIN_CONSENSUS_PARAMS_H
 
+#include "hash.h"
 #include "uint256.h"
 #include <map>
 #include <string>
@@ -65,6 +66,9 @@ struct Params {
 
     /** Hardfork parameters */
     int64_t HardforkTime;
+    HashAlgorithm PowAlgorithmForTime(int64_t nTime) const {
+        return HashAlgorithm::SHA256d;
+    }
 
     uint256 defaultAssumeValid;
 };

--- a/src/hash.h
+++ b/src/hash.h
@@ -15,11 +15,12 @@
 
 #include <vector>
 
-enum class HashAlgorithm {
+enum class HashAlgorithm: unsigned int {
     SHA256,
     SHA256d,
     RIPEMD160,
     HASH160,
+    NUM_HASH_ALGOS,
 };
 
 typedef uint256 ChainCode;

--- a/src/hash.h
+++ b/src/hash.h
@@ -15,6 +15,13 @@
 
 #include <vector>
 
+enum class HashAlgorithm {
+    SHA256,
+    SHA256d,
+    RIPEMD160,
+    HASH160,
+};
+
 typedef uint256 ChainCode;
 
 /** A hasher class for Bitcoin's 256-bit hash (double SHA-256). */

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -51,6 +51,18 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
         nBits = CalculateNextWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
     }
 
+    if (params.PowAlgorithmForTime(pblock->nTime) != params.PowAlgorithmForTime(pindexLast->nTime)) {
+        // Adjust target for PoW change
+        arith_uint256 bnNew;
+        bnNew.SetCompact(nBits);
+        bnNew <<= params.nPowChangeTargetShift;
+        const arith_uint256 bnPowLimit = UintToArith256(params.powLimit);
+        if (bnNew > bnPowLimit) {
+            bnNew = bnPowLimit;
+        }
+        nBits = bnNew.GetCompact();
+    }
+
     return nBits;
 }
 

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -13,6 +13,8 @@
 #include "crypto/common.h"
 #include "streams.h"
 
+#include <cstdlib>
+
 uint256 CBlockHeader::GetHash(const Consensus::Params& consensusParams) const
 {
     CDataStream ss(SER_GETHASH, PROTOCOL_VERSION);
@@ -35,6 +37,9 @@ uint256 CBlockHeader::GetHash(const Consensus::Params& consensusParams) const
         case HashAlgorithm::HASH160:
             CHash160().Write(pbegin, ss.size()).Finalize((unsigned char*)&hash);
             break;
+        case HashAlgorithm::NUM_HASH_ALGOS:
+            // Should be impossible
+            abort();
     }
 
     return hash;

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -8,11 +8,42 @@
 #include "hash.h"
 #include "tinyformat.h"
 #include "utilstrencodings.h"
+#include "chainparams.h"
+#include "consensus/params.h"
 #include "crypto/common.h"
+#include "streams.h"
+
+uint256 CBlockHeader::GetHash(const Consensus::Params& consensusParams) const
+{
+    CDataStream ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << *this;
+
+    const auto pbegin = (const unsigned char *)&ss.begin()[0];
+    uint256 hash;
+
+    const HashAlgorithm algo = consensusParams.PowAlgorithmForTime(nTime);
+    switch (algo) {
+        case HashAlgorithm::SHA256:
+            CSHA256().Write(pbegin, ss.size()).Finalize((unsigned char*)&hash);
+            break;
+        case HashAlgorithm::SHA256d:
+            CHash256().Write(pbegin, ss.size()).Finalize((unsigned char*)&hash);
+            break;
+        case HashAlgorithm::RIPEMD160:
+            CRIPEMD160().Write(pbegin, ss.size()).Finalize((unsigned char*)&hash);
+            break;
+        case HashAlgorithm::HASH160:
+            CHash160().Write(pbegin, ss.size()).Finalize((unsigned char*)&hash);
+            break;
+    }
+
+    return hash;
+}
 
 uint256 CBlockHeader::GetHash() const
 {
-    return SerializeHash(*this);
+    const Consensus::Params& consensusParams = Params().GetConsensus();
+    return GetHash(consensusParams);
 }
 
 std::string CBlock::ToString() const

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -10,6 +10,10 @@
 #include "serialize.h"
 #include "uint256.h"
 
+namespace Consensus {
+    struct Params;
+}
+
 /** Nodes collect new transactions into a block, hash them into a hash tree,
  * and scan through nonce values to make the block's hash satisfy proof-of-work
  * requirements.  When they solve the proof-of-work, they broadcast the block
@@ -60,6 +64,7 @@ public:
         return (nBits == 0);
     }
 
+    uint256 GetHash(const Consensus::Params&) const;
     uint256 GetHash() const;
 
     int64_t GetBlockTime() const

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2989,6 +2989,10 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
     if (block.GetBlockTime() > nAdjustedTime + 2 * 60 * 60)
         return state.Invalid(false, REJECT_INVALID, "time-too-new", "block timestamp too far in the future");
 
+    if (consensusParams.PowAlgorithmForTime(block.GetBlockTime()) != consensusParams.PowAlgorithmForTime(pindexPrev->GetBlockTime()) && block.GetBlockTime() < pindexPrev->GetBlockTime()) {
+        return state.Invalid(false, REJECT_INVALID, "pow-reversed", "cannot reverse PoW change");
+    }
+
     // Reject outdated version blocks when 95% (75% on testnet) of the network has upgraded:
     // check for version 2, 3 and 4 upgrades
     if((block.nVersion < 2 && nHeight >= consensusParams.BIP34Height) ||


### PR DESCRIPTION
This adds the ability to define a PoW change to any of SHA256 (not double), RIPEMD160, or "Hash160" (SHA256+RIPEMD160). It is intentionally flexible such that other, more realistic options can be added without making a final decision until the last minute (to prevent anyone getting a head start on ASICs).

The hardfork will also trigger an immediate drop of the difficulty to about 0.0001% (target is shifted left by 2<sup>20</sup>) of its previous level. (This is a _guess_ based on comparing pre-ASIC to post-ASIC network hashrate, not a final decision.)

<hr>

`CBlockHeader::GetHash` uses `Consensus::Params` to decide what hashing algorithm to use. Once the hardfork has completed, this can be cleaned up nicer.

The 10 blocks after the first non-SHA2 block are limited such that their timestamp cannot precede the hardfork-defined timestamp. This shouldn't have any real effect, and can also be removed once we get past the hardfork.

<hr>

For testing, regtest is configured to rotate between the total of all four (ie, including SHA256d) algorithms.

(No PoW change is defined for mainnet or testnet in this PR.)