### PR TITLE
Activate Segwit immediately with hardfork

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -64,7 +64,7 @@ struct Params {
     uint256 nMinimumChainWork;
 
     /** Hardfork parameters */
-    int64_t HardforkTime;
+    int64_t HardforkTime;  //!< Must be exactly 1 [second] after the final pre-hardfork block, and that block must exclusively have nTime==HardforkTime-1
 
     uint256 defaultAssumeValid;
 };

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -622,6 +622,10 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     for (int j = 0; j < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++j) {
         Consensus::DeploymentPos pos = Consensus::DeploymentPos(j);
         ThresholdState state = VersionBitsState(pindexPrev, consensusParams, pos, versionbitscache);
+        if (pos == Consensus::DEPLOYMENT_SEGWIT && IsWitnessEnabled(pindexPrev, consensusParams)) {
+            // Segwit was activated via hardfork
+            state = THRESHOLD_ACTIVE;
+        }
         switch (state) {
             case THRESHOLD_DEFINED:
             case THRESHOLD_FAILED:

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -562,7 +562,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     pblock->nNonce = 0;
 
     // NOTE: If at some point we support pre-segwit miners post-segwit-activation, this needs to take segwit support into consideration
-    const bool fPreSegWit = (THRESHOLD_ACTIVE != VersionBitsState(pindexPrev, consensusParams, Consensus::DEPLOYMENT_SEGWIT, versionbitscache));
+    const bool fPreSegWit = !IsWitnessEnabled(pindexPrev, consensusParams);
 
     UniValue aCaps(UniValue::VARR); aCaps.push_back("proposal");
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2914,6 +2914,9 @@ static bool CheckIndexAgainstCheckpoint(const CBlockIndex* pindexPrev, CValidati
 
 bool IsWitnessEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& params)
 {
+    if (pindexPrev && pindexPrev->GetBlockTime() == params.HardforkTime - 1) {
+        return true;
+    }
     LOCK(cs_main);
     return (VersionBitsState(pindexPrev, params, Consensus::DEPLOYMENT_SEGWIT, versionbitscache) == THRESHOLD_ACTIVE);
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3040,7 +3040,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Co
     //   {0xaa, 0x21, 0xa9, 0xed}, and the following 32 bytes are SHA256^2(witness root, witness nonce). In case there are
     //   multiple, the last one is used.
     bool fHaveWitness = false;
-    if (VersionBitsState(pindexPrev, consensusParams, Consensus::DEPLOYMENT_SEGWIT, versionbitscache) == THRESHOLD_ACTIVE) {
+    if (IsWitnessEnabled(pindexPrev, consensusParams)) {
         int commitpos = GetWitnessCommitmentIndex(block);
         if (commitpos != -1) {
             bool malleated = false;


### PR DESCRIPTION
`IsWitnessEnabled` determines if Segwit is active for block X based on looking at block X minus 1.

For this reason, we must guarantee the `HardforkTime` is set to exactly the nTime of the previous block plus one (and it must be the only block with this nTime).